### PR TITLE
ajuste de naveção: goBack na seta do HeaderForm

### DIFF
--- a/frontend/src/components/insurance/headerForm.js
+++ b/frontend/src/components/insurance/headerForm.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import {Fab, LinearProgress} from "@material-ui/core";
 import ArrowBack from '@material-ui/icons/ArrowBack';
+import { useHistory } from "react-router-dom";
 
 function HeaderForm(props) {
     const normalise = (value, min, max) => (value - min) * 100 / (max - min);
+    const { goBack } = useHistory();
 
     return (
         <div className="layout-form__header" >
             <div>
-                <Fab className="layout-form__header__fab"  >
+                <Fab className="layout-form__header__fab" onClick={goBack} >
                   <ArrowBack className="layout-form__header__fab__icon"/>
                 </Fab>
             </div>


### PR DESCRIPTION
Utilizei a função goBack do hook useHistory para acrescentar funcionalidade de voltar à página anterior, para a seta à esquerda (tag Fab) do componente HeaderForm.